### PR TITLE
Tell NPM not to publish examples/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.sw[ponm]
+examples/build.js
+examples/node_modules/
+gh-pages
+node_modules/
+npm-debug.log
+examples/
+preview.png


### PR DESCRIPTION
This will speed up `npm install aframe-cubemap-component` as no images will be downloaded.