### PR TITLE
Delegate texture encoding to renderer system

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ An [A-Frame](https://aframe.io) component for creating a skybox from a cubemap.
 
 ### Properties
 
-|  Property   |               Description               | Default Value  |
-| :---------: | :-------------------------------------: | :------------: |
-|   folder    | Path to the folder holding your cubemap |      none      |
-| edgeLength  |  Controls the dimensions of the skybox  |      5000      |
-|     ext     |           The image extension           |      jpg       |
-| transparent |       Enable transparency for png       |     false      |
-|  encoding   |    The [texture encoding][0] to use     | LinearEncoding |
+|  Property   |               Description               | Default Value |
+| :---------: | :-------------------------------------: | :-----------: |
+|   folder    | Path to the folder holding your cubemap |     none      |
+| edgeLength  |  Controls the dimensions of the skybox  |     5000      |
+|     ext     |           The image extension           |      jpg      |
+| transparent |       Enable transparency for png       |     false     |
 
 By default, the height, width, and depth of the skybox are set to 5000. In other words, the dimensions of the skybox are 5000x5000x5000.
 
@@ -66,5 +65,3 @@ Install and use by directly including the [browser files](dist):
   </a-scene>
 </body>
 ```
-
-[0]: https://threejs.org/docs/index.html#api/en/textures/Texture.encoding

--- a/examples/encoding/index.html
+++ b/examples/encoding/index.html
@@ -9,9 +9,7 @@
     example. With colorManagement: false, Yokohama appears too dark.
     -->
     <a-scene renderer="colorManagement: true">
-      <a-entity
-        cubemap="folder: /assets/Yokohama3/; encoding: sRGBEncoding"
-      ></a-entity>
+      <a-entity cubemap="folder: /assets/Yokohama3/;"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -25,9 +25,6 @@ AFRAME.registerComponent("cubemap", {
       type: "boolean",
       default: false,
     },
-    encoding: {
-      default: "LinearEncoding",
-    },
   },
 
   /**
@@ -38,6 +35,7 @@ AFRAME.registerComponent("cubemap", {
     // entity data
     var el = this.el;
     var data = this.data;
+    var rendererSystem = el.sceneEl.systems.renderer;
 
     // Path to the folder containing the 6 cubemap images
     var srcPath = data.folder;
@@ -77,15 +75,9 @@ AFRAME.registerComponent("cubemap", {
     var loader = new THREE.CubeTextureLoader();
     loader.setPath(srcPath);
     loader.load(urls, function (texture) {
-      // Set texture encoding.
-      let encoding = THREE[data.encoding];
-      if (!encoding) {
-        console.warn(
-          `Unknown texture encoding: ${value}. Defaulting to THREE.LinearEncoding`
-        );
-        encoding = THREE.LinearEncoding;
-      }
-      texture.encoding = encoding;
+      // Have the renderer system set texture encoding as in A-Frame core.
+      // https://github.com/bryik/aframe-cubemap-component/issues/13#issuecomment-626238202
+      rendererSystem.applyColorCorrection(texture);
 
       // Clone ShaderMaterial (necessary for multiple cubemaps)
       var skyBoxMaterial = skyBoxShader.clone();


### PR DESCRIPTION
Rather than require users to set texture encoding explicitly (via a property), @kfarr [found a way](https://github.com/bryik/aframe-cubemap-component/issues/13#issuecomment-626238202) to make A-Frame's renderer system to set it for us.

Losing the `encoding` property does prevent users from creating cubemaps with different texture encodings, but I don't think it is advisable to mix Linear and sRGB encoded textures anyway (AFAIK sRGB output requires enabling colorManagement which [changes the renderer](https://github.com/aframevr/aframe/blob/ccd877c3036eea7c1b795846dea9411fb3475395/src/systems/renderer.js#L36)).



