### PR TITLE
Support passing a-asset ID as a `folder` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ An [A-Frame](https://aframe.io) component for creating a skybox from a cubemap.
 
 By default, the height, width, and depth of the skybox are set to 5000. In other words, the dimensions of the skybox are 5000x5000x5000.
 
+**Note:** `folder` can also be an ID to an `<a-cubemap>` asset. See `./examples/tests/a-assets/` for an example.
+
 ### Events
 
 |       Name        |                 Description                 |

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ An [A-Frame](https://aframe.io) component for creating a skybox from a cubemap.
 
 ### Properties
 
-|  Property  |               Description               | Default Value |
-| :--------: | :-------------------------------------: | :-----------: |
-|   folder   | Path to the folder holding your cubemap |     none      |
-| edgeLength |  Controls the dimensions of the skybox  |     5000      |
-|    ext     |           The image extension           |      jpg      |
+|  Property  |                      Description                      | Default Value |
+| :--------: | :---------------------------------------------------: | :-----------: |
+|   folder   | Path to the folder holding your cubemap or a selector |     none      |
+| edgeLength |         Controls the dimensions of the skybox         |     5000      |
+|    ext     |                  The image extension                  |      jpg      |
 
 By default, the height, width, and depth of the skybox are set to 5000. In other words, the dimensions of the skybox are 5000x5000x5000.
 
-**Note:** `folder` can also be an ID to an `<a-cubemap>` asset. See `./examples/tests/a-assets/` for an example.
+**Note:** `folder` can also be an ID to an `<a-cubemap>` asset. See `./examples/tests/a-assets/`.
 
 ### Events
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,6 +36,7 @@
     <a href="./tests/ext/index.html">PNG extension</a>
     <a href="./tests/fade/index.html">Fade</a>
     <a href="./tests/encoding/index.html">Texture encoding</a>
+    <a href="./tests/a-assets/index.html">Use with a-assets</a>
 
     <div class="github-fork-ribbon-wrapper right">
       <div class="github-fork-ribbon" style="background: #3482aa;">

--- a/examples/tests/a-assets/index.html
+++ b/examples/tests/a-assets/index.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>A-Frame Cubemap Component - a-assets</title>
+    <script src="../../build.js"></script>
+  </head>
+  <body>
+    <a-scene>
+      <a-assets>
+        <a-cubemap id="sky">
+          <!--The order of these images is important!-->
+          <!-- https://threejs.org/docs/index.html#api/en/textures/CubeTexture -->
+          <img src="../../assets/Yokohama3/posx.jpg" />
+          <img src="../../assets/Yokohama3/negx.jpg" />
+          <img src="../../assets/Yokohama3/posy.jpg" />
+          <img src="../../assets/Yokohama3/negy.jpg" />
+          <img src="../../assets/Yokohama3/posz.jpg" />
+          <img src="../../assets/Yokohama3/negz.jpg" />
+        </a-cubemap>
+      </a-assets>
+      <a-entity cubemap="folder:#sky"></a-entity>
+    </a-scene>
+  </body>
+</html>

--- a/examples/tests/a-assets/index.html
+++ b/examples/tests/a-assets/index.html
@@ -4,20 +4,53 @@
     <script src="../../build.js"></script>
   </head>
   <body>
-    <a-scene>
+    <a-scene stats>
       <a-assets>
-        <a-cubemap id="sky">
+        <a-cubemap id="yokohama">
           <!--The order of these images is important!-->
-          <!-- https://threejs.org/docs/index.html#api/en/textures/CubeTexture -->
-          <img src="../../assets/Yokohama3/posx.jpg" />
-          <img src="../../assets/Yokohama3/negx.jpg" />
-          <img src="../../assets/Yokohama3/posy.jpg" />
-          <img src="../../assets/Yokohama3/negy.jpg" />
-          <img src="../../assets/Yokohama3/posz.jpg" />
-          <img src="../../assets/Yokohama3/negz.jpg" />
+          <!--posx-->
+          <img src="https://i.imgur.com/t3ixTMn.jpg" />
+          <!--negx-->
+          <img src="https://i.imgur.com/cyrsG1a.jpg" />
+          <!--posy-->
+          <img src="https://i.imgur.com/hNa2WA4.jpg?1" />
+          <!--negy-->
+          <img src="https://i.imgur.com/XX4cRwQ.jpg" />
+          <!--posz-->
+          <img src="https://i.imgur.com/vPRQ9Bc.jpg" />
+          <!--negz-->
+          <img src="https://i.imgur.com/fDRkOEl.jpg" />
+        </a-cubemap>
+        <a-cubemap id="goldenGate">
+          <!--The order of these images is important!-->
+          <img src="../../assets/GoldenGatebridge2/posx.jpg" />
+          <img src="../../assets/GoldenGatebridge2/negx.jpg" />
+          <img src="../../assets/GoldenGatebridge2/posy.jpg" />
+          <img src="../../assets/GoldenGatebridge2/negy.jpg" />
+          <img src="../../assets/GoldenGatebridge2/posz.jpg" />
+          <img src="../../assets/GoldenGatebridge2/negz.jpg" />
         </a-cubemap>
       </a-assets>
-      <a-entity cubemap="folder:#sky"></a-entity>
+      <a-entity id="skybox" cubemap="folder:#yokohama"></a-entity>
     </a-scene>
+    <!--A button and a script to switch panoramas.-->
+    <button
+      id="switchButton"
+      style="position: absolute; top: 10px; right: 10px;"
+    >
+      Switch
+    </button>
+    <script>
+      const switchButton = document.querySelector("#switchButton");
+      switchButton.addEventListener("click", switchPanoramas);
+
+      let panorama = "yokohama";
+
+      function switchPanoramas() {
+        const skybox = document.querySelector("#skybox");
+        panorama = panorama === "yokohama" ? "goldenGate" : "yokohama";
+        skybox.setAttribute("cubemap", `folder:#${panorama}`);
+      }
+    </script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -87,19 +87,37 @@ AFRAME.registerComponent("cubemap", {
     }
 
     if (data.ext !== oldData.ext || data.folder !== oldData.folder) {
-      // Load textures.
-      // Path to the folder containing the 6 cubemap images
-      const srcPath = data.folder;
-      // Cubemap image files must follow this naming scheme
-      // from: http://threejs.org/docs/index.html#Reference/Textures/CubeTexture
-      var urls = ["posx", "negx", "posy", "negy", "posz", "negz"];
-      // Apply extension
-      urls = urls.map(function (val) {
-        return val + "." + data.ext;
-      });
+      // File extension and/or folder property have changed, so reload textures.
 
-      // Set folder path, and load cubemap textures
-      this.loader.setPath(srcPath);
+      // Determine the URLs to load.
+      var urls;
+      // srcPath is either a literal path to a folder, or a selector to an <a-cubemap>
+      // asset.
+      const srcPath = data.folder;
+      if (srcPath && srcPath[0] === "#") {
+        // srcPath is a selector to an <a-cubemap> asset
+        const assetEl = document.querySelector(srcPath);
+        if (assetEl === null) {
+          // Bail out
+          console.error(
+            `cubemap component given a selector to a non-existent asset: ${srcPath}`
+          );
+          return;
+        }
+        urls = assetEl.srcs;
+      } else {
+        // srcPath is a folder path
+        this.loader.setPath(srcPath);
+        // Cubemap image files must follow this naming scheme
+        // from: https://threejs.org/docs/index.html#api/en/textures/CubeTexture
+        urls = ["posx", "negx", "posy", "negy", "posz", "negz"];
+        // Apply extension
+        urls = urls.map(function (val) {
+          return val + "." + data.ext;
+        });
+      }
+
+      // Load textures
       this.loader.load(urls, onTextureLoad.bind(this));
 
       function onTextureLoad(texture) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-cubemap-component",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This MR may make `cubemap` slightly easier to use with A-Frame's asset management system. 

It is [not necessary](https://github.com/bryik/aframe-cubemap-component/issues/14#issuecomment-627018602) for front-loading assets or caching, but users probably expect to be able to pass a selector.

One complication is that the order of images in `<a-assets>` matters:

```html
<a-assets>
  <a-cubemap id="yokohama">
    <!--The order of these images is important!-->
    <!-- https://threejs.org/docs/index.html#api/en/textures/CubeTexture -->
    <img src="../../assets/Yokohama3/posx.jpg" />
    <img src="../../assets/Yokohama3/negx.jpg" />
    <img src="../../assets/Yokohama3/posy.jpg" />
    <img src="../../assets/Yokohama3/negy.jpg" />
    <img src="../../assets/Yokohama3/posz.jpg" />
    <img src="../../assets/Yokohama3/negz.jpg" />
  </a-cubemap>
</a-assets>
```

i.e. if `<img src="../../assets/Yokohama3/negx.jpg" />` was moved to the top of the list, then the cubemap would not render correctly (`negx.jpg` would be displayed in the positive-x position). I could add a function to parse and sort the array of images, but...I'm not sure it's worthwhile.