### PR TITLE
Update compatibility with threejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ AFRAME.registerComponent("cubemap", {
 
     // A Cubemap can be rendered as a mesh composed of a BoxBufferGeometry and
     // ShaderMaterial. EdgeLength will scale the mesh
-    this.geometry = new THREE.BoxBufferGeometry(1, 1, 1);
+    this.geometry = new THREE.BoxGeometry(1, 1, 1);
 
     // Now for the ShaderMaterial.
     const shader = THREE.ShaderLib["cube"];

--- a/index.js
+++ b/index.js
@@ -54,8 +54,9 @@ AFRAME.registerComponent("cubemap", {
       transparent: true
     }).clone();
     
-    //https://github.com/mrdoob/three.js/wiki/Migration-Guide#145--146
-    //they changed the name of the uniform from tCube to envMap, this variable helps us keep track of the name across three js versions
+   // Starting in Three.js v146, `envMap` changed to `tCube`.
+    // This variable helps us keep track of the name across Three.js versions.
+    // https://github.com/mrdoob/three.js/wiki/Migration-Guide#145--146
     this.envMapUniformName = this.material.uniforms["envMap"] ? "envMap" : "tCube";
   
 
@@ -70,8 +71,6 @@ AFRAME.registerComponent("cubemap", {
 
     // A dummy texture is needed (otherwise the shader will be invalid and spew
     // a million errors)
-    
-  //   this.material.uniforms["envMap"].value = new THREE.Texture();
     this.material.uniforms[this.envMapUniformName].value = new THREE.Texture();
 
     this.loader = new THREE.CubeTextureLoader();

--- a/index.js
+++ b/index.js
@@ -53,16 +53,27 @@ AFRAME.registerComponent("cubemap", {
       side: THREE.BackSide,
       transparent: true
     }).clone();
+    
+    //https://github.com/mrdoob/three.js/wiki/Migration-Guide#145--146
+    //they changed the name of the uniform from tCube to envMap, this variable helps us keep track of the name across three js versions
+    this.envMapUniformName = this.material.uniforms["envMap"] ? "envMap" : "tCube";
+  
+
     // Threejs seems to have removed the 'tCube' uniform.
     // Workaround from: https://stackoverflow.com/a/59454999/6591491
+    
     Object.defineProperty(this.material, "envMap", {
       get: function () {
-        return this.uniforms.envMap.value;
+          return this.uniforms.envMap ? this.uniforms.envMap.value : this.uniforms.tCube.value;
       },
     });
+
     // A dummy texture is needed (otherwise the shader will be invalid and spew
     // a million errors)
-    this.material.uniforms["envMap"].value = new THREE.Texture();
+    
+  //   this.material.uniforms["envMap"].value = new THREE.Texture();
+    this.material.uniforms[this.envMapUniformName].value = new THREE.Texture();
+
     this.loader = new THREE.CubeTextureLoader();
 
     // We can create the mesh now and update the material with a texture later on
@@ -135,8 +146,8 @@ AFRAME.registerComponent("cubemap", {
         rendererSystem.applyColorCorrection(texture);
 
         // Apply cubemap texture to shader uniforms and dispose of the old texture.
-        const oldTexture = this.material.uniforms["envMap"].value;
-        this.material.uniforms["envMap"].value = texture;
+        const oldTexture = this.material.uniforms[this.envMapUniformName].value;
+        this.material.uniforms[this.envMapUniformName].value = texture;
         if (oldTexture) {
           oldTexture.dispose();
         }
@@ -153,7 +164,7 @@ AFRAME.registerComponent("cubemap", {
    */
   remove: function () {
     this.geometry.dispose();
-    this.material.uniforms["envMap"].value.dispose();
+    this.material.uniforms[this.envMapUniformName].value.dispose();
     this.material.dispose();
     this.el.removeObject3D("cubemap");
   },


### PR DESCRIPTION
Hi, I noticed that the component was no longer working in the latest A-Frame releases (1.4.0 and up). After some poking around, I found the issue has to do with two updates to three.js.
 **1.** BoxBufferGeometry has been deprecated. [link](https://github.com/mrdoob/three.js/wiki/Migration-Guide#144--145)
 **2.** The cube shader in ShaderLib has different uniforms now. envMap is now tCube.  [link](https://github.com/mrdoob/three.js/wiki/Migration-Guide#145--146) 
It only took a few changes to get everything up to speed. I changed BoxBufferGeometry to BoxGeometry, and I added some logic to make sure we are using the correct uniforms. Now everything works like a charm! I made a PR, so please take a look when you get a chance. I really like this component and I think it would be great if it stayed available for future use! Cheers
