### PR TITLE
Update examples to A-Frame v1.6.0

### DIFF
--- a/examples/tests/change-cubemap/index.html
+++ b/examples/tests/change-cubemap/index.html
@@ -1,19 +1,25 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Change Cubemap Test</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>
     <a-scene stats>
-      <a-entity id="skybox" cubemap="folder: /examples/assets/Yokohama3/"></a-entity>
+      <a-entity
+        id="skybox"
+        cubemap="folder: /examples/assets/Yokohama3/"
+      ></a-entity>
     </a-scene>
     <script type="text/javascript">
       setTimeout(changeBackground, 5000);
 
       function changeBackground() {
         const skybox = document.querySelector("#skybox");
-        skybox.setAttribute("cubemap", "folder: /examples/assets/GoldenGateBridge2/");
+        skybox.setAttribute(
+          "cubemap",
+          "folder: /examples/assets/GoldenGateBridge2/"
+        );
       }
     </script>
   </body>

--- a/examples/tests/edgeLength/index.html
+++ b/examples/tests/edgeLength/index.html
@@ -1,13 +1,15 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - edgeLength Test</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>
     <a-scene>
       <!-- At this size, the skybox is no longer seamless. -->
-      <a-entity cubemap="folder: /examples/assets/Yokohama3/; edgeLength: 50"></a-entity>
+      <a-entity
+        cubemap="folder: /examples/assets/Yokohama3/; edgeLength: 50"
+      ></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/tests/encoding/index.html
+++ b/examples/tests/encoding/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Yokohama Encoding</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>

--- a/examples/tests/ext/index.html
+++ b/examples/tests/ext/index.html
@@ -1,12 +1,14 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Extension test</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>
     <a-scene>
-      <a-entity cubemap="folder:/examples/assets/MilkyWayPNG/; ext:png;"></a-entity>
+      <a-entity
+        cubemap="folder:/examples/assets/MilkyWayPNG/; ext:png;"
+      ></a-entity>
       <a-entity
         cubemap="folder:/examples/assets/TransparentPNG/;
                          ext:png;

--- a/examples/tests/fade/index.html
+++ b/examples/tests/fade/index.html
@@ -1,11 +1,15 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Fade</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>
     <a-scene stats>
+      <a-entity
+        id="skybox"
+        cubemap="folder: /examples/assets/Yokohama3/"
+      ></a-entity>
       <a-sphere
         id="sphere"
         radius="4000"
@@ -14,7 +18,6 @@
         animation__fadeOut="property: material.opacity; from: 0.0; to: 1.0; startEvents: fadeOut"
       >
       </a-sphere>
-      <a-entity id="skybox" cubemap="folder: /examples/assets/Yokohama3/"></a-entity>
     </a-scene>
 
     <script>
@@ -23,38 +26,34 @@
         sphere = document.querySelector("#sphere"),
         cubemapPath = "folder: /examples/assets/Yokohama3/";
 
-      function toggleBackground() {
-        cubemapPath =
-          cubemapPath === "folder: /examples/assets/Yokohama3/"
-            ? "folder: /examples/assets/GoldenGateBridge2/"
-            : "folder: /examples/assets/Yokohama3/";
+      // When the fadeout animation completes, swap the cubemap and fade in.
+      sphere.addEventListener("animationcomplete", function (event) {
+        if (event.detail.name === "animation__fadeout") {
+          skybox.setAttribute("cubemap", cubemapPath);
+          sphere.emit("fadeIn");
+        }
+      });
 
-        sphere.emit("fadeOut");
-        sphere.addEventListener("animationcomplete", function (event) {
-          if (event.detail.name === "animation__fadeout") {
-            skybox.setAttribute("cubemap", cubemapPath);
-            sphere.emit("fadeIn");
-          }
-        });
+      function run() {
+        // fade in first cubemap
+        sphere.emit("fadeIn");
+
+        // swap cubemap every 5 seconds
+        setInterval(() => {
+          sphere.emit("fadeOut");
+
+          // Swap
+          cubemapPath =
+            cubemapPath === "folder: /examples/assets/Yokohama3/"
+              ? "folder: /examples/assets/GoldenGateBridge2/"
+              : "folder: /examples/assets/Yokohama3/";
+        }, 5000);
       }
 
       if (scene.hasLoaded) {
         run();
       } else {
         scene.addEventListener("loaded", run);
-      }
-
-      function run() {
-        // Cubemap has loaded, so fade in.
-        sphere.emit("fadeIn");
-
-        // Toggle the background.
-        toggleBackground();
-
-        // Toggle the background back and forth every 5 seconds.
-        skybox.addEventListener("cubemapLoaded", () => {
-          setTimeout(toggleBackground, 5000);
-        });
       }
     </script>
   </body>

--- a/examples/tests/multi-cubemaps/index.html
+++ b/examples/tests/multi-cubemaps/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Multiple Cubemap Test</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>

--- a/examples/yokohama/index.html
+++ b/examples/yokohama/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>A-Frame Cubemap Component - Yokohama</title>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="/index.js"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,8 @@
     <a href="./examples/tests/ext/index.html">PNG extension</a>
     <a href="./examples/tests/fade/index.html">Fade</a>
     <a href="./examples/tests/encoding/index.html">Texture encoding</a>
+
+    <h3>Not currently working</h3>
     <a href="./examples/tests/a-assets/index.html">Use with a-assets</a>
 
     <div class="github-fork-ribbon-wrapper right">

--- a/index.js
+++ b/index.js
@@ -51,21 +51,24 @@ AFRAME.registerComponent("cubemap", {
       uniforms: shader.uniforms,
       depthWrite: false,
       side: THREE.BackSide,
-      transparent: true
+      transparent: true,
     }).clone();
-    
-   // Starting in Three.js v146, `envMap` changed to `tCube`.
+
+    // Starting in Three.js v146, `envMap` changed to `tCube`.
     // This variable helps us keep track of the name across Three.js versions.
     // https://github.com/mrdoob/three.js/wiki/Migration-Guide#145--146
-    this.envMapUniformName = this.material.uniforms["envMap"] ? "envMap" : "tCube";
-  
+    this.envMapUniformName = this.material.uniforms["envMap"]
+      ? "envMap"
+      : "tCube";
 
     // Threejs seems to have removed the 'tCube' uniform.
     // Workaround from: https://stackoverflow.com/a/59454999/6591491
-    
+
     Object.defineProperty(this.material, "envMap", {
       get: function () {
-          return this.uniforms.envMap ? this.uniforms.envMap.value : this.uniforms.tCube.value;
+        return this.uniforms.envMap
+          ? this.uniforms.envMap.value
+          : this.uniforms.tCube.value;
       },
     });
 


### PR DESCRIPTION
This MR updates all the examples to use the latest version of A-Frame. 

- All except the "fade" example only involved updating the version number.

- The "a-assets" example is currently broken, not sure why. Seems like imgur no longer makes it easy to direct link to an image, but the example remained broken even after using only local images. Probably something changed in A-Frame's asset management system or in Three.js' loaders.